### PR TITLE
Thunderbird support

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -48,6 +48,11 @@ function startup(aData, aReason) {
   if (!aData.installPath.isDirectory())
     fileuri = Services.io.newURI('jar:' + fileuri.spec + '!/', null, null);
   Services.io.getProtocolHandler('resource').QueryInterface(Ci.nsIResProtocolHandler).setSubstitution('aboutstartup', fileuri);
+  Components.utils.import('resource://aboutstartup/patchtbwindow.jsm');
+  patchTBWindow.startup({
+    aData: aData, isAppShutdown: aReason == APP_SHUTDOWN
+    , menuItem: {label: "about:startup", id: "aboutStartupMenuitem", url: "about:startup"}
+  });
   Components.utils.import('resource://aboutstartup/startupdata.jsm');
 }
 
@@ -56,6 +61,8 @@ function shutdown(aData, aReason) {
     try {
       StartupData.save();
     } catch(e) {}
+  Components.utils.import('resource://aboutstartup/patchtbwindow.jsm');
+  patchTBWindow.shutdown({aData: aData, isAppShutdown: aReason == APP_SHUTDOWN});
   Services.io.getProtocolHandler('resource').QueryInterface(Ci.nsIResProtocolHandler).setSubstitution('aboutstartup', null);
   Cm.unregisterFactory(AboutStartup.prototype.classID, AboutStartupFactory);
 }

--- a/install.rdf
+++ b/install.rdf
@@ -39,6 +39,15 @@
       </Description>
     </em:targetApplication>
 
+    <!-- Thunderbird -->
+    <em:targetApplication>
+      <Description>
+        <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
+        <em:minVersion>5.0b1</em:minVersion>
+        <em:maxVersion>12.0a1</em:maxVersion>
+      </Description>
+    </em:targetApplication>
+
     <!-- Front End MetaData -->
     <em:name>About startup</em:name>
     <em:description>Startup timings display.</em:description>

--- a/patchtbwindow.jsm
+++ b/patchtbwindow.jsm
@@ -1,0 +1,98 @@
+let EXPORTED_SYMBOLS = ['patchTBWindow'];
+
+const Cc = Components.classes;
+const Ci = Components.interfaces;
+const Cu = Components.utils;
+const Cm = Components.manager;
+
+Cu.import("resource://gre/modules/Services.jsm");
+
+let patchTBWindow = {};
+
+let _menuItem = null;
+
+function isThunderbird()
+{
+  let APP_ID = Services.appinfo.QueryInterface(Ci.nsIXULRuntime).ID;
+  return APP_ID == "{3550f703-e582-4d05-9a08-453d09bdfdc6}";
+}
+
+var global = this;
+
+function monkeyPatchWindow(w, loadedAlready) {
+  let doIt = function () {
+    w.removeEventListener("load", doIt, false);
+    
+    let taskPopup = w.document.getElementById("taskPopup");
+    let tabmail = w.document.getElementById("tabmail");
+    let menuitem = w.document.getElementById(_menuItem.id);
+
+    // Check the windows is a mail:3pane
+    // and should be patched or not
+    if (!taskPopup || !tabmail || menuitem)
+      return;
+
+    menuitem = w.document.createElement("menuitem");
+    menuitem.addEventListener("command", function () {
+      w.document.getElementById("tabmail").openTab(
+        "contentTab",
+        { contentPage: _menuItem.url }
+      );
+    }, false);
+    menuitem.setAttribute("label", _menuItem.label);
+    menuitem.setAttribute("id", _menuItem.id);
+    taskPopup.appendChild(menuitem);
+  };
+  if (loadedAlready)
+    doIt();
+  else
+    w.addEventListener("load", doIt, false);
+}
+
+function unMonkeyPatchWindow(w) {
+  let menuitem = w.document.getElementById(_menuItem.id);
+  menuitem.parentNode.removeChild(menuitem);
+}
+
+function startup(options) {
+  _menuItem = options.menuItem;
+  
+  // For Thunderbird, since there's no URL bar, we add a menu item to make it
+  // more discoverable.
+  if (isThunderbird()) {
+    // Thunderbird-specific JSM
+    Cu.import("resource:///modules/iteratorUtils.jsm", global);
+
+    // Patch all existing windows
+    for each (let w in fixIterator(Services.wm.getEnumerator("mail:3pane"), Ci.nsIDOMWindow)) {
+      // True means the window's been loaded already, so add the menu item right
+      // away (the default is: wait for the "load" event).
+      monkeyPatchWindow(w.window, true);
+    }
+
+    // Patch all future windows
+    Services.ww.registerNotification({
+      observe: function (aSubject, aTopic, aData) {
+        if (aTopic == "domwindowopened") {
+          aSubject.QueryInterface(Ci.nsIDOMWindow);
+          monkeyPatchWindow(aSubject.window);
+        }
+      },
+    });
+  }
+}
+
+function shutdown(options) {
+  if (options.isAppShutdown) return;
+
+  if (isThunderbird) {
+    // Un-patch all existing windows
+    for each (let w in fixIterator(Services.wm.getEnumerator("mail:3pane")))
+      unMonkeyPatchWindow(w);
+    
+    _menuItem = null;
+  }
+}
+
+patchTBWindow.startup = startup;
+patchTBWindow.shutdown = shutdown;


### PR DESCRIPTION
Hi,

Some months ago, in v.0.1.5 I had to modify `startupdata.jsm` to survive the lack of `sessionRestore` under Thunderbird.
But now, in v0.1.7 it is enough to add a menuitem.

Therefore I played with @tarasglek's [about:telemetry](https://github.com/tarasglek/about-telemetry) and tried to make a feasible Thunderbird support for `about:support`.

Of course, it wouldn't be a problem, if @tarasglek himself or anybody other would like to add this support. :)
