### PR TITLE
Don't allow untrusted content on about: url

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -29,7 +29,7 @@ AboutStartup.prototype = {
 
   getURIFlags: function(uri)
   {
-    return Ci.nsIAboutModule.URI_SAFE_FOR_UNTRUSTED_CONTENT | Ci.nsIAboutModule.ALLOW_SCRIPT;
+    return Ci.nsIAboutModule.ALLOW_SCRIPT;
   }
 };
 


### PR DESCRIPTION
This should help `about:startup` to load with Mozilla 22+.
